### PR TITLE
differentiate empty string argument vs non-existent argument

### DIFF
--- a/src/yang-parser.litcoffee
+++ b/src/yang-parser.litcoffee
@@ -220,7 +220,7 @@ optional.
 The result of the `statement` parser is an initialized `YangStatement` object.
 
     statement = keyword.bind (kw) ->
-      (sep.bind -> argument).option().bind (arg) ->
+      (sep.bind -> argument).option(false).bind (arg) ->
         strict = true if kw[1] is 'yang-version' and arg is '1.1'
         optSep.bind -> semiOrBlock.bind (sst) ->
           P.unit new YangStatement kw[0], kw[1], arg, sst


### PR DESCRIPTION
As discussed in corenova/yang-js#60, there's a need to differentiate the case where a given statement is followed by an empty string argument vs. when there is no argument at all so that we can validate proper syntax of the YANG statement.

This change makes the argument default option case to return `false` instead of an empty string `''`.